### PR TITLE
lz4context: use correct way to free context

### DIFF
--- a/include/tarxx.h
+++ b/include/tarxx.h
@@ -1101,7 +1101,7 @@ namespace tarxx {
 
             ~lz4_ctx()
             {
-                free(ctx_);
+                LZ4F_freeCompressionContext(ctx_);
             }
 
             LZ4F_cctx* get()


### PR DESCRIPTION
the current way to free the lz4 context
is not correct and leaks memory.
Instead using `free`, `LZ4F_freeCompressionContext` must be used to free all memory allocated by lz4