### PR TITLE
construction: add Platform to constructor as parameter

### DIFF
--- a/tarxx-example.cpp
+++ b/tarxx-example.cpp
@@ -179,7 +179,7 @@ int main(const int argc, char* const* const argv)
                 break;
 #    endif
             case 'f':
-                filename = optarg;
+                filename = (optarg != nullptr ? optarg : "");
                 break;
             case 't':
                 tar_type = static_cast<tarxx::tarfile::tar_type>(std::stoi(optarg));


### PR DESCRIPTION
this allows users to pass their custom implementation of the platform object.
It can be used to support to change behaviors of
the default implementation.
An example for this is the `mod_time` function
can be overwritten in case it's required to
suppress timestamps for legal reasons.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under BSD-2-Clause License Version

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>